### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,9 @@ on:
         type: string
         required: true
 
+permissions:
+  contents: read
+
 env:
   ANKI_VERSION: ${{ github.event.inputs.anki_version || '25.02.5' }}
 


### PR DESCRIPTION
Potential fix for [https://github.com/my-flow/anki-sync-server/security/code-scanning/1](https://github.com/my-flow/anki-sync-server/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root level of the workflow. This block will specify the least privileges required for the workflow to function correctly. Based on the workflow's steps, it primarily interacts with repository contents (e.g., checking out code) and uses Docker-related actions. Therefore, we will set `contents: read` as the minimal permission required. If additional permissions are needed in the future, they can be added explicitly.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
